### PR TITLE
ci: Jobの改善

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,10 +25,11 @@ jobs:
       - name: Code lint
         run: yarn lint
 
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    needs: [code-lint]
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    needs:
+      - code-lint
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -58,10 +59,20 @@ jobs:
           name: artifact
           path: out
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/dev'
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: artifact
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
+          publish_dir: ./
           publish_branch: master
           force_orphan: true


### PR DESCRIPTION
## 概要

GitHub ActionsのJobの改善を行った

## 詳細

buildジョブとdeployジョブを分離し、push時にもbuildをするようにして、現時点での成果物を閲覧できるようにした。