### PR TITLE
build: ESLintの修正

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,26 +4,39 @@
     "node": true,
     "es6": true
   },
-  "plugins": ["@typescript-eslint", "react"],
+  "plugins": ["react"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:prettier/recommended",
-    "prettier/@typescript-eslint"
+    "plugin:prettier/recommended"
   ],
   "parserOptions": {
     "sourceType": "module",
-    "project": "tsconfig.json",
     "ecmaVersion": 2020,
     "ecmaFeatures": {
       "jsx": true
     }
   },
   "rules": {
-    "@typescript-eslint/no-explicit-any": "error",
-    "react/prop-types": "off",
     "react/react-in-jsx-scope": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "plugins": ["@typescript-eslint"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "prettier/@typescript-eslint"
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "projesct": "tsconfig.json"
+      },
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "error",
+        "react/prop-types": "off"
+      }
+    }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,9 @@
       "jsx": true
     }
   },
+  "settings": {
+    "react": { "version": "detect" }
+  },
   "rules": {
     "react/react-in-jsx-scope": "off"
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,7 @@
       ],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {
-        "projesct": "tsconfig.json"
+        "project": "tsconfig.json"
       },
       "rules": {
         "@typescript-eslint/no-explicit-any": "error",


### PR DESCRIPTION
## 概要

ESLintが`*.js`のLint時にパースエラーを発生させる問題を修正した。

## 詳細

`*.js`でもTypeScriptのパーサを使用していたので、`*.ts`,`*.tsx`のときのみTypeScriptのパーサを使用するように変更した。