### PR TITLE
ci: Jobの速度改善

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,8 +27,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs:
-      - code-lint
     if: github.event_name == 'push'
     steps:
       - name: Checkout
@@ -61,7 +59,9 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - code-lint
+      - build
     if: github.ref == 'refs/heads/dev'
     steps:
       - name: Download Artifact


### PR DESCRIPTION
## 概要

GitHub ActionsのJobの速度が遅かったので改善した。

## 詳細

今までは、Code Lint→Build→Deployという流れだったが、(Code Lint/Build)→Deployという流れに変更した。